### PR TITLE
Release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 
+## [1.4.1] - 2020-12-25
+
+### Fixed
+- fix: Do not stop listening to changeSettings event on stop plugin, as it has to be restarted if `cli` setting changes to `true`
+
 ## [1.4.0] - 2020-12-25
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mocks-server/plugin-inquirer-cli",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mocks-server/plugin-inquirer-cli",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Plugin for Mocks server. Displays an interactive CLI",
   "keywords": [
     "mocks-server-plugin",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=mocks-server
 sonar.projectKey=mocks-server-plugin-inquirer-cli
-sonar.projectVersion=1.4.0
+sonar.projectVersion=1.4.1
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/src/Cli.js
+++ b/src/Cli.js
@@ -112,6 +112,7 @@ class Cli {
       this._header.bind(this),
       this._alertsHeader.bind(this)
     );
+    this._stopListeningChangeSettings = this._core.onChangeSettings(this._onChangeSettings);
     this._inited = true;
     return Promise.resolve();
   }
@@ -126,10 +127,8 @@ class Cli {
     this._started = true;
     if (this._stopListeningChangeMocks) {
       this._stopListeningChangeMocks();
-      this._stopListeningChangeSettings();
       this._stopListeningChangeAlerts();
     }
-    this._stopListeningChangeSettings = this._core.onChangeSettings(this._onChangeSettings);
     this._stopListeningChangeAlerts = this._core.onChangeAlerts(this._onChangeAlerts);
     this._stopListeningChangeMocks = this._core.onChangeMocks(this._onChangeMocks);
     this._logLevel = this._settings.get("log");
@@ -143,7 +142,6 @@ class Cli {
     }
     this._started = false;
     this._stopListeningChangeMocks();
-    this._stopListeningChangeSettings();
     this._stopListeningChangeAlerts();
     this._settings.set("log", this._logLevel);
     this._cli.removeListeners();

--- a/test/e2e/support/InteractiveCliRunner.js
+++ b/test/e2e/support/InteractiveCliRunner.js
@@ -12,7 +12,6 @@ const { wait } = require("./utils");
 const CliRunner = require("./CliRunner");
 
 const LOG = "[CLI]: ";
-const SCREEN_SEPARATOR = ">> Mocks server";
 
 module.exports = class InteractiveCliRunner {
   constructor(cliArguments, cliOptions) {
@@ -25,11 +24,7 @@ module.exports = class InteractiveCliRunner {
 
   async getCurrentScreen() {
     await wait(500);
-    const allLogs = this._cli.allLogs;
-    const lastLog = allLogs[allLogs.length - 1];
-    return lastLog.includes(SCREEN_SEPARATOR)
-      ? `${SCREEN_SEPARATOR}${lastLog.split(SCREEN_SEPARATOR).pop()}`
-      : lastLog;
+    return this._cli.currentScreen;
   }
 
   async logCurrentScreen() {
@@ -50,6 +45,10 @@ module.exports = class InteractiveCliRunner {
 
   kill() {
     return this._cli.kill();
+  }
+
+  flush() {
+    this._cli.flush();
   }
 
   get logs() {

--- a/test/unit/src/Cli.spec.js
+++ b/test/unit/src/Cli.spec.js
@@ -66,6 +66,10 @@ describe("Cli", () => {
       await cli.init();
       expect(inquirerMocks.stubs.Inquirer.callCount).toEqual(0);
     });
+
+    it("should listen to settings change", async () => {
+      expect(coreInstance.onChangeSettings.callCount).toEqual(1);
+    });
   });
 
   describe("when settings are changed", () => {
@@ -286,9 +290,10 @@ describe("Cli", () => {
       expect.assertions(3);
       inquirerMocks.reset();
       await cli.stop();
-      expect(removeChangeSettingsSpy.callCount).toEqual(1);
       expect(removeChangeMocksSpy.callCount).toEqual(1);
       expect(removeChangeAlertsSpy.callCount).toEqual(1);
+      // it still hast to listen to change settings to restart the plugin in case cli setting changes
+      expect(removeChangeSettingsSpy.callCount).toEqual(0);
     });
 
     it("should not stop if it was already stopped", async () => {


### PR DESCRIPTION
### Fixed
- fix: Do not stop listening to changeSettings event on stop plugin, as it has to be restarted if `cli` setting changes to `true`